### PR TITLE
Different URL for getting input variables data

### DIFF
--- a/src/PySXO/workflow.py
+++ b/src/PySXO/workflow.py
@@ -183,7 +183,7 @@ class Workflow(Base):
                         "type": 'string',
                         # TODO: hardcoding is_required as true here...is this right?
                         # This may not be generic enough. More research required.
-                        "is_required": True if variable_id in self.start_config.property_schema.required else False
+                        "is_required": True if i.id in self.start_config.property_schema.required else False
                     }
                 }
                 for i in self.start_config.property_schema.input_variables

--- a/src/PySXO/workflow.py
+++ b/src/PySXO/workflow.py
@@ -183,7 +183,7 @@ class Workflow(Base):
                         "type": 'string',
                         # TODO: hardcoding is_required as true here...is this right?
                         # This may not be generic enough. More research required.
-                        "is_required": True
+                        "is_required": True if variable_id in self.start_config.property_schema.required else False
                     }
                 }
                 for i in self.start_config.property_schema.input_variables


### PR DESCRIPTION
URL /api/v1/workflows/ui/start_config is bugged. Show boolean input variables as required.
/api/v1/workflows/start_config is used instead.